### PR TITLE
fix my sloppy oversight of asUint8 missing unchecked suffix in asBool…

### DIFF
--- a/src/libraries/BytesParsing.sol
+++ b/src/libraries/BytesParsing.sol
@@ -96,7 +96,7 @@ library BytesParsing {
     bytes memory encoded,
     uint offset
   ) internal pure returns (bool, uint) {
-    (uint8 val, uint nextOffset) = asUint8(encoded, offset);
+    (uint8 val, uint nextOffset) = asUint8Unchecked(encoded, offset);
     if (val & 0xfe != 0)
       revert InvalidBoolVal(val);
 

--- a/src/libraries/BytesParsing.sol
+++ b/src/libraries/BytesParsing.sol
@@ -96,15 +96,11 @@ library BytesParsing {
     bytes memory encoded,
     uint offset
   ) internal pure returns (bool, uint) {
-    (uint8 val, uint nextOffset) = asUint8Unchecked(encoded, offset);
-    if (val & 0xfe != 0)
-      revert InvalidBoolVal(val);
+    (uint8 ret, uint nextOffset) = asUint8Unchecked(encoded, offset);
+    if (ret & 0xfe != 0)
+      revert InvalidBoolVal(ret);
 
-    bool ret;
-    assembly ("memory-safe") {
-      ret := val
-    }
-    return (ret, nextOffset);
+    return (ret != 0, nextOffset);
   }
 
   function asBool(

--- a/src/libraries/BytesParsing.sol
+++ b/src/libraries/BytesParsing.sol
@@ -96,11 +96,17 @@ library BytesParsing {
     bytes memory encoded,
     uint offset
   ) internal pure returns (bool, uint) {
-    (uint8 ret, uint nextOffset) = asUint8Unchecked(encoded, offset);
-    if (ret & 0xfe != 0)
-      revert InvalidBoolVal(ret);
+    (uint8 val, uint nextOffset) = asUint8Unchecked(encoded, offset);
+    if (val & 0xfe != 0)
+      revert InvalidBoolVal(val);
 
-    return (ret != 0, nextOffset);
+    uint cleanedVal = uint(val);
+    bool ret;
+    //skip 2x iszero opcode
+    assembly ("memory-safe") {
+      ret := cleanedVal
+    }
+    return (ret, nextOffset);
   }
 
   function asBool(


### PR DESCRIPTION
I made sloppy mistakes in my proposal [here](https://github.com/wormhole-foundation/wormhole-solidity-sdk/pull/24#discussion_r1444100188) by using `asUint8` instead of `asUint8Unchecked`.

Additionally, as it turns out, the inline assembly is not safe because solc is actually no cleaning up the upper 31 bytes of `val` (as I expected it would), so there's no way to avoid the cost of the two ISZERO opcodes after all. I missed that because it happened to insert cleanup instructions in my Playground example, which I believed to be equivalent but then it wasn't...