### PR TITLE
Change BSC RPC URL

### DIFF
--- a/src/testing/WormholeRelayerTest.sol
+++ b/src/testing/WormholeRelayerTest.sol
@@ -298,7 +298,7 @@ abstract contract WormholeRelayerTest is Test {
             name: "bsc testnet",
             url: vm.envOr(
                 "BSC_TESTNET_RPC_URL",
-                string("https://bsc-testnet.public.blastapi.io")
+                string("https://bsc-testnet-rpc.publicnode.com/")
             ),
             relayer: IWormholeRelayer(
                 0x80aC94316391752A193C1c47E27D382b507c93F3


### PR DESCRIPTION
The Blast API has been flaky and/or competitive when we've used it in the Example NTT repo. https://github.com/wormhole-foundation/example-native-token-transfers/issues/340

This PR updates the RPC endpoint in the SDK in order to improve reliability.