### PR TITLE
lower BytesParsing solidity version req, add len prefixed slicing

### DIFF
--- a/src/libraries/BytesParsing.sol
+++ b/src/libraries/BytesParsing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache 2
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.4;
 
 library BytesParsing {
   uint256 private constant freeMemoryPtr = 0x40;
@@ -19,6 +19,24 @@ library BytesParsing {
       revert LengthMismatch(encoded.length, expected);
   }
 
+  //Summary of all remaining functions:
+  //
+  //Each function has two versions:
+  // 1. unchecked - no bounds checking (uses suffix `Unchecked`)
+  // 2. checked (no suffix)
+  //
+  //The canoncial/recommended way of parsing data to be maximally gas efficient is to use the
+  //  unchecked versions and do a manual check at the end using `checkLength` to ensure that
+  //  encoded data was consumed exactly (neither too short nor too long).
+  //
+  //Functions:
+  // * slice
+  // * sliceUint<n>Prefixed - n in {8, 16, 32} - parses n bytes of length prefix followed by data
+  // * asAddress
+  // * asBool
+  // * asUint<8*n> - n in {1, ..., 32}, i.e. asUint8, asUint16, ..., asUint256
+  // * asBytes<n>  - n in {1, ..., 32}, i.e. asBytes1, asBytes2, ..., asBytes32
+
   function sliceUnchecked(
     bytes memory encoded,
     uint offset,
@@ -28,7 +46,8 @@ library BytesParsing {
     if (length == 0)
       return (new bytes(0), offset);
 
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, length)
       ret := mload(freeMemoryPtr)
 
@@ -67,13 +86,28 @@ library BytesParsing {
     }
   }
 
-  function slice(
+  function sliceUint8PrefixedUnchecked(
     bytes memory encoded,
-    uint offset,
-    uint length
-  ) internal pure returns (bytes memory ret, uint nextOffset) {
-    (ret, nextOffset) = sliceUnchecked(encoded, offset, length);
-    checkBound(nextOffset, encoded.length);
+    uint offset
+  ) internal pure returns (bytes memory, uint) {
+    (uint8 len, uint nextOffset) = asUint8Unchecked(encoded, offset);
+    return sliceUnchecked(encoded, nextOffset, uint(len));
+  }
+
+  function sliceUint16PrefixedUnchecked(
+    bytes memory encoded,
+    uint offset
+  ) internal pure returns (bytes memory, uint) {
+    (uint16 len, uint nextOffset) = asUint16Unchecked(encoded, offset);
+    return sliceUnchecked(encoded, nextOffset, uint(len));
+  }
+
+  function sliceUint32PrefixedUnchecked(
+    bytes memory encoded,
+    uint offset
+  ) internal pure returns (bytes memory, uint) {
+    (uint32 len, uint nextOffset) = asUint32Unchecked(encoded, offset);
+    return sliceUnchecked(encoded, nextOffset, uint(len));
   }
 
   function asAddressUnchecked(
@@ -82,14 +116,6 @@ library BytesParsing {
   ) internal pure returns (address, uint) {
     (uint160 ret, uint nextOffset) = asUint160Unchecked(encoded, offset);
     return (address(ret), nextOffset);
-  }
-
-  function asAddress(
-    bytes memory encoded,
-    uint offset
-  ) internal pure returns (address ret, uint nextOffset) {
-    (ret, nextOffset) = asAddressUnchecked(encoded, offset);
-    checkBound(nextOffset, encoded.length);
   }
 
   function asBoolUnchecked(
@@ -103,10 +129,54 @@ library BytesParsing {
     uint cleanedVal = uint(val);
     bool ret;
     //skip 2x iszero opcode
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := cleanedVal
     }
     return (ret, nextOffset);
+  }
+
+  //checked functions
+
+  function slice(
+    bytes memory encoded,
+    uint offset,
+    uint length
+  ) internal pure returns (bytes memory ret, uint nextOffset) {
+    (ret, nextOffset) = sliceUnchecked(encoded, offset, length);
+    checkBound(nextOffset, encoded.length);
+  }
+
+  function sliceUint8Prefixed(
+    bytes memory encoded,
+    uint offset
+  ) internal pure returns (bytes memory ret, uint nextOffset) {
+    (ret, nextOffset) = sliceUint8PrefixedUnchecked(encoded, offset);
+    checkBound(nextOffset, encoded.length);
+  }
+
+  function sliceUint16Prefixed(
+    bytes memory encoded,
+    uint offset
+  ) internal pure returns (bytes memory ret, uint nextOffset) {
+    (ret, nextOffset) = sliceUint16PrefixedUnchecked(encoded, offset);
+    checkBound(nextOffset, encoded.length);
+  }
+
+  function sliceUint32Prefixed(
+    bytes memory encoded,
+    uint offset
+  ) internal pure returns (bytes memory ret, uint nextOffset) {
+    (ret, nextOffset) = sliceUint32PrefixedUnchecked(encoded, offset);
+    checkBound(nextOffset, encoded.length);
+  }
+
+  function asAddress(
+    bytes memory encoded,
+    uint offset
+  ) internal pure returns (address ret, uint nextOffset) {
+    (ret, nextOffset) = asAddressUnchecked(encoded, offset);
+    checkBound(nextOffset, encoded.length);
   }
 
   function asBool(
@@ -127,7 +197,8 @@ for (let bytes = 1; bytes <= 32; ++bytes) {
   bytes memory encoded,
   uint offset
 ) internal pure returns (uint${bits} ret, uint nextOffset) {
-  assembly ("memory-safe") {
+  /// @solidity memory-safe-assembly
+  assembly {
     nextOffset := add(offset, ${bytes})
     ret := mload(add(encoded, nextOffset))
   }
@@ -145,7 +216,8 @@ function asBytes${bytes}Unchecked(
   bytes memory encoded,
   uint offset
 ) internal pure returns (bytes${bytes} ret, uint nextOffset) {
-  assembly ("memory-safe") {
+  /// @solidity memory-safe-assembly
+  assembly {
     ret := mload(add(encoded, add(offset, wordSize)))
     nextOffset := add(offset, ${bytes})
   }
@@ -167,7 +239,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint8 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 1)
       ret := mload(add(encoded, nextOffset))
     }
@@ -185,7 +258,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes1 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 1)
     }
@@ -203,7 +277,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint16 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 2)
       ret := mload(add(encoded, nextOffset))
     }
@@ -221,7 +296,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes2 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 2)
     }
@@ -239,7 +315,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint24 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 3)
       ret := mload(add(encoded, nextOffset))
     }
@@ -257,7 +334,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes3 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 3)
     }
@@ -275,7 +353,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint32 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 4)
       ret := mload(add(encoded, nextOffset))
     }
@@ -293,7 +372,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes4 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 4)
     }
@@ -311,7 +391,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint40 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 5)
       ret := mload(add(encoded, nextOffset))
     }
@@ -329,7 +410,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes5 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 5)
     }
@@ -347,7 +429,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint48 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 6)
       ret := mload(add(encoded, nextOffset))
     }
@@ -365,7 +448,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes6 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 6)
     }
@@ -383,7 +467,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint56 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 7)
       ret := mload(add(encoded, nextOffset))
     }
@@ -401,7 +486,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes7 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 7)
     }
@@ -419,7 +505,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint64 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 8)
       ret := mload(add(encoded, nextOffset))
     }
@@ -437,7 +524,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes8 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 8)
     }
@@ -455,7 +543,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint72 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 9)
       ret := mload(add(encoded, nextOffset))
     }
@@ -473,7 +562,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes9 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 9)
     }
@@ -491,7 +581,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint80 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 10)
       ret := mload(add(encoded, nextOffset))
     }
@@ -509,7 +600,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes10 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 10)
     }
@@ -527,7 +619,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint88 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 11)
       ret := mload(add(encoded, nextOffset))
     }
@@ -545,7 +638,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes11 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 11)
     }
@@ -563,7 +657,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint96 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 12)
       ret := mload(add(encoded, nextOffset))
     }
@@ -581,7 +676,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes12 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 12)
     }
@@ -599,7 +695,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint104 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 13)
       ret := mload(add(encoded, nextOffset))
     }
@@ -617,7 +714,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes13 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 13)
     }
@@ -635,7 +733,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint112 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 14)
       ret := mload(add(encoded, nextOffset))
     }
@@ -653,7 +752,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes14 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 14)
     }
@@ -671,7 +771,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint120 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 15)
       ret := mload(add(encoded, nextOffset))
     }
@@ -689,7 +790,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes15 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 15)
     }
@@ -707,7 +809,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint128 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 16)
       ret := mload(add(encoded, nextOffset))
     }
@@ -725,7 +828,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes16 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 16)
     }
@@ -743,7 +847,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint136 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 17)
       ret := mload(add(encoded, nextOffset))
     }
@@ -761,7 +866,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes17 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 17)
     }
@@ -779,7 +885,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint144 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 18)
       ret := mload(add(encoded, nextOffset))
     }
@@ -797,7 +904,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes18 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 18)
     }
@@ -815,7 +923,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint152 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 19)
       ret := mload(add(encoded, nextOffset))
     }
@@ -833,7 +942,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes19 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 19)
     }
@@ -851,7 +961,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint160 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 20)
       ret := mload(add(encoded, nextOffset))
     }
@@ -869,7 +980,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes20 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 20)
     }
@@ -887,7 +999,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint168 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 21)
       ret := mload(add(encoded, nextOffset))
     }
@@ -905,7 +1018,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes21 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 21)
     }
@@ -923,7 +1037,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint176 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 22)
       ret := mload(add(encoded, nextOffset))
     }
@@ -941,7 +1056,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes22 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 22)
     }
@@ -959,7 +1075,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint184 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 23)
       ret := mload(add(encoded, nextOffset))
     }
@@ -977,7 +1094,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes23 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 23)
     }
@@ -995,7 +1113,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint192 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 24)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1013,7 +1132,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes24 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 24)
     }
@@ -1031,7 +1151,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint200 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 25)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1049,7 +1170,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes25 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 25)
     }
@@ -1067,7 +1189,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint208 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 26)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1085,7 +1208,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes26 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 26)
     }
@@ -1103,7 +1227,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint216 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 27)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1121,7 +1246,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes27 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 27)
     }
@@ -1139,7 +1265,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint224 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 28)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1157,7 +1284,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes28 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 28)
     }
@@ -1175,7 +1303,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint232 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 29)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1193,7 +1322,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes29 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 29)
     }
@@ -1211,7 +1341,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint240 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 30)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1229,7 +1360,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes30 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 30)
     }
@@ -1247,7 +1379,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint248 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 31)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1265,7 +1398,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes31 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 31)
     }
@@ -1283,7 +1417,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (uint256 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       nextOffset := add(offset, 32)
       ret := mload(add(encoded, nextOffset))
     }
@@ -1301,7 +1436,8 @@ function asBytes${bytes}(
     bytes memory encoded,
     uint offset
   ) internal pure returns (bytes32 ret, uint nextOffset) {
-    assembly ("memory-safe") {
+    /// @solidity memory-safe-assembly
+    assembly {
       ret := mload(add(encoded, add(offset, wordSize)))
       nextOffset := add(offset, 32)
     }


### PR DESCRIPTION
* lower solidity version requirement of BytesParsing as proposed [here](https://github.com/wormhole-foundation/wormhole-solidity-sdk/pull/45)
* add doc to summarize available functionality and intended use
* add prefixed based slicing since it's a fairly common use case
* reorder functions to push boiler-plate lower in the file
