### PR TITLE
feat: adds interface for optional ERC20 functions

### DIFF
--- a/src/interfaces/token/IERC20Metadata.sol
+++ b/src/interfaces/token/IERC20Metadata.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "IERC20/IERC20.sol";
+
+//https://eips.ethereum.org/EIPS/eip-20
+interface IERC20Metadata is IERC20 {
+  function name() external view returns (string memory);
+  function symbol() external view returns (string memory);
+  function decimals() external view returns (uint8);
+}


### PR DESCRIPTION
These are `decimals`, `name` and `symbol`. This interface is useful when dealing with tokens in the context of working with the token bridge, since it requires calling the `decimals` function.